### PR TITLE
Refactor outbound collection logic to Bloc pattern

### DIFF
--- a/lib/modules/outbound/collection_task/bloc/outbound_collection_bloc.dart
+++ b/lib/modules/outbound/collection_task/bloc/outbound_collection_bloc.dart
@@ -1,0 +1,996 @@
+import 'dart:async';
+
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
+import 'package:hive/hive.dart';
+
+import '../models/barcode_content.dart';
+import '../models/mat_control_info.dart';
+import '../models/outbound_collected_summary.dart';
+import '../models/outbound_collection_record.dart';
+import '../models/outbound_collection_repository.dart';
+import '../models/outbound_down_shelves_payload.dart';
+import '../models/outbound_inventory_record.dart';
+import '../models/outbound_task_item.dart';
+
+part 'outbound_collection_event.dart';
+part 'outbound_collection_state.dart';
+enum _ScanStep { barcode2d, site, quantity }
+
+class _OperationQuantities {
+  _OperationQuantities({required this.taskQty, required this.collectedQty});
+
+  final double taskQty;
+  final double collectedQty;
+}
+class OutboundCollectionBloc
+    extends Bloc<OutboundCollectionEvent, OutboundCollectionState> {
+  OutboundCollectionBloc({
+    required this.repository,
+    required this.taskNo,
+    required this.taskId,
+    required this.taskComment,
+    required this.workStation,
+    required this.storeRoom,
+    required this.siteFlag,
+    required this.batchFlag,
+    required this.userId,
+    required this.roleId,
+    required this.roomTag,
+    required Future<Box<OutboundCollectionRecord>> localBox,
+  })  : _localBoxFuture = localBox,
+        super(OutboundCollectionState.initial(
+          storeRoom: storeRoom,
+          siteFlag: siteFlag,
+          batchFlag: batchFlag,
+        )) {
+    on<_OutboundCollectionInitialized>(_onInitialized);
+    on<OutboundCollectionBarcodeScanned>(_onBarcodeScanned);
+    on<OutboundCollectionSubmitRequested>(_onSubmitRequested);
+    on<OutboundCollectionPendingActionConfirmed>(
+        _onPendingActionConfirmed);
+    on<OutboundCollectionCloseRequested>(_onCloseRequested);
+    on<OutboundCollectionSelectionToggled>(_onSelectionToggled);
+    on<OutboundCollectionFinishSelected>(_onFinishSelected);
+    on<OutboundCollectionSuccessCleared>(_onSuccessCleared);
+    on<OutboundCollectionErrorCleared>(_onErrorCleared);
+    on<OutboundCollectionDetailOpened>(_onDetailOpened);
+    on<OutboundCollectionExceptionOpened>(_onExceptionOpened);
+    on<OutboundCollectionSupplierOpened>(_onSupplierOpened);
+    on<OutboundCollectionNavigationCleared>(_onNavigationCleared);
+    on<OutboundCollectionCloseAcknowledged>(_onCloseAcknowledged);
+
+    add(const _OutboundCollectionInitialized());
+  }
+
+  final OutboundCollectionRepository repository;
+  final String taskNo;
+  final String taskId;
+  final String taskComment;
+  final String workStation;
+  final String storeRoom;
+  final String siteFlag;
+  final String batchFlag;
+  final String userId;
+  final String roleId;
+  final String roomTag;
+  final Future<Box<OutboundCollectionRecord>> _localBoxFuture;
+  Box<OutboundCollectionRecord>? _localBox;
+
+  Future<void> _onInitialized(
+    _OutboundCollectionInitialized event,
+    Emitter<OutboundCollectionState> emit,
+  ) async {
+    await _initialize();
+  }
+
+  Future<void> _onBarcodeScanned(
+    OutboundCollectionBarcodeScanned event,
+    Emitter<OutboundCollectionState> emit,
+  ) async {
+    await _handleBarcodeScanned(event.raw);
+  }
+
+  Future<void> _onSubmitRequested(
+    OutboundCollectionSubmitRequested event,
+    Emitter<OutboundCollectionState> emit,
+  ) async {
+    await _submitCollection();
+  }
+
+  Future<void> _onPendingActionConfirmed(
+    OutboundCollectionPendingActionConfirmed event,
+    Emitter<OutboundCollectionState> emit,
+  ) async {
+    await _confirmPendingAction(event.confirmed);
+  }
+
+  Future<void> _onCloseRequested(
+    OutboundCollectionCloseRequested event,
+    Emitter<OutboundCollectionState> emit,
+  ) async {
+    _requestClose();
+  }
+
+  Future<void> _onSelectionToggled(
+    OutboundCollectionSelectionToggled event,
+    Emitter<OutboundCollectionState> emit,
+  ) async {
+    _toggleSelection(event.outTaskItemId);
+  }
+
+  Future<void> _onFinishSelected(
+    OutboundCollectionFinishSelected event,
+    Emitter<OutboundCollectionState> emit,
+  ) async {
+    await _finishSelected();
+  }
+
+  Future<void> _onSuccessCleared(
+    OutboundCollectionSuccessCleared event,
+    Emitter<OutboundCollectionState> emit,
+  ) async {
+    _clearSuccessMessage();
+  }
+
+  Future<void> _onErrorCleared(
+    OutboundCollectionErrorCleared event,
+    Emitter<OutboundCollectionState> emit,
+  ) async {
+    _clearErrorMessage();
+  }
+
+  Future<void> _onDetailOpened(
+    OutboundCollectionDetailOpened event,
+    Emitter<OutboundCollectionState> emit,
+  ) async {
+    _openCollectionDetail();
+  }
+
+  Future<void> _onExceptionOpened(
+    OutboundCollectionExceptionOpened event,
+    Emitter<OutboundCollectionState> emit,
+  ) async {
+    _openExceptionTask();
+  }
+
+  Future<void> _onSupplierOpened(
+    OutboundCollectionSupplierOpened event,
+    Emitter<OutboundCollectionState> emit,
+  ) async {
+    _openSupplierTask();
+  }
+
+  Future<void> _onNavigationCleared(
+    OutboundCollectionNavigationCleared event,
+    Emitter<OutboundCollectionState> emit,
+  ) async {
+    _clearNavigation();
+  }
+
+  Future<void> _onCloseAcknowledged(
+    OutboundCollectionCloseAcknowledged event,
+    Emitter<OutboundCollectionState> emit,
+  ) async {
+    _acknowledgeCloseHandled();
+  }
+  Future<void> _initialize() async {
+    emit(state.copyWith(status: OutboundCollectionStatus.loading));
+    try {
+      if (!Hive.isAdapterRegistered(OutboundCollectionRecordAdapter().typeId)) {
+        Hive.registerAdapter(OutboundCollectionRecordAdapter());
+      }
+    } catch (_) {
+      // ignore duplicate registration errors
+    }
+
+    try {
+      _localBox ??= await _localBoxFuture;
+      final String roomMatControl = await repository.getRoomMatControl(taskId);
+      final List<OutboundTaskItem> items = await repository.fetchTaskItems(
+        taskNo: taskNo,
+        userId: userId,
+        roleId: roleId,
+        workStation: workStation,
+        roomTag: roomTag,
+        taskComment: taskComment,
+      );
+      final List<OutboundCollectionRecord> local = _localBox!.values.toList();
+      emit(state.copyWith(
+        status: OutboundCollectionStatus.ready,
+        taskItems: items,
+        filteredItems: items,
+        roomMatControl: roomMatControl,
+        collectionRecords: local,
+        messageLabel: '请扫描库位',
+      ));
+    } catch (error) {
+      emit(state.copyWith(
+        status: OutboundCollectionStatus.failure,
+        errorMessage: error.toString(),
+      ));
+    }
+  }
+  bool _isQuantity(String input) {
+    final double? value = double.tryParse(input);
+    if (value == null) {
+      return false;
+    }
+    if (value <= 0 || value > 999999) {
+      return false;
+    }
+    final List<String> parts = input.split('.');
+    if (parts.length > 2) {
+      return false;
+    }
+    bool _isDigits(String text) {
+      for (final int code in text.codeUnits) {
+        if (code < 48 || code > 57) {
+          return false;
+        }
+      }
+      return text.isNotEmpty;
+    }
+
+    if (!_isDigits(parts.first)) {
+      return false;
+    }
+    if (parts.length == 2) {
+      if (!_isDigits(parts[1]) || parts[1].length > 7) {
+        return false;
+      }
+    }
+    return true;
+  }
+  Future<void> _handleBarcodeScanned(String raw) async {
+    if (state.status != OutboundCollectionStatus.ready) {
+      return;
+    }
+    final String barcode = raw.trim();
+    if (barcode.isEmpty) {
+      emit(state.copyWith(errorMessage: '条码不能为空'));
+      return;
+    }
+    _ScanStep step;
+    if (barcode.contains('*')) {
+      step = _ScanStep.barcode2d;
+    } else if (barcode.startsWith(r'$KW$')) {
+      step = _ScanStep.site;
+    } else if (_isQuantity(barcode)) {
+      step = _ScanStep.quantity;
+    } else {
+      emit(state.copyWith(errorMessage: _buildMessage('条码格式错误,')));
+      return;
+    }
+
+    try {
+      switch (step) {
+        case _ScanStep.barcode2d:
+          await _handle2DBarcode(barcode);
+          break;
+        case _ScanStep.site:
+          await _handleSiteBarcode(barcode);
+          break;
+        case _ScanStep.quantity:
+          _handleQuantity(barcode);
+          break;
+      }
+      final String message = _buildMessage('');
+      if (message.trim().isEmpty) {
+        final double qty = state.quantityInput ?? 0;
+        await _dealQuantity(qty, state.matControlFlag);
+        _initializeCollect();
+      }
+      emit(state.copyWith(
+        messageLabel: _buildMessage(''),
+        errorMessage: null,
+      ));
+    } catch (error) {
+      emit(state.copyWith(
+        errorMessage: error.toString(),
+        messageLabel: _buildMessage(''),
+      ));
+    }
+  }
+  Future<void> _handle2DBarcode(String barcode) async {
+    final BarcodeContent barcodeContent =
+        await repository.analysisBarcode(barcode);
+    final bool isNewMatTask = barcode.contains('*BN');
+
+    final MatControlInfo matControlInfo =
+        await repository.getMatControl(barcodeContent.matCode);
+
+    String matSendControl = matControlInfo.sendControl.isEmpty
+        ? '0'
+        : matControlInfo.sendControl;
+
+    String serialNumber = '';
+    String batchNo = '';
+    double qty = 1;
+    String matCode = barcodeContent.matCode;
+    String matInnerCode = '';
+    String matName = '';
+    final int matControl = matControlInfo.controlType;
+
+    if (!isNewMatTask) {
+      if (matControl == 0) {
+        if (barcodeContent.sn.isEmpty) {
+          throw Exception('物料$matCode序列号为空，无法采集');
+        }
+        if (state.scannedSerials
+            .containsKey('${barcodeContent.matCode}@${barcodeContent.sn}')) {
+          throw Exception('序列号${barcodeContent.sn}已经采集');
+        }
+        serialNumber = barcodeContent.sn;
+        batchNo = '';
+        qty = 1;
+        for (final OutboundCollectionRecord record in state.collectionRecords) {
+          if (record.sn == barcodeContent.sn) {
+            throw Exception(
+              '物料${barcodeContent.matCode}序列号${barcodeContent.sn}在库位${record.storeSite}已采集,禁止重复采集',
+            );
+          }
+        }
+      } else if (matControl == 1 || matControl == 2) {
+        if ((matSendControl == '0' && state.roomMatControl == '0') ||
+            state.roomMatControl == '1') {
+          await _checkMat(barcodeContent.matCode, barcodeContent.batchNo);
+          await _checkMtlSite(
+            state.storeSite,
+            barcodeContent.sn,
+            barcodeContent.matCode,
+            matControl.toString(),
+          );
+        }
+        serialNumber = '';
+        batchNo = barcodeContent.sn;
+      } else {
+        throw Exception('物料$matCode控制属性非法');
+      }
+    } else {
+      if (matControl == 0) {
+        if (barcodeContent.sn.isEmpty) {
+          throw Exception('物料$matCode序列号为空，无法采集');
+        }
+        serialNumber = barcodeContent.sn;
+        batchNo = barcodeContent.batchNo.isEmpty
+            ? barcodeContent.sn
+            : barcodeContent.batchNo;
+        qty = 1;
+        if (state.scannedSerials
+            .containsKey('${barcodeContent.matCode}@${barcodeContent.sn}')) {
+          throw Exception('序列号${barcodeContent.sn}已经采集');
+        }
+      } else if (matControl == 1 || matControl == 2) {
+        if ((matSendControl == '0' && state.roomMatControl == '0') ||
+            state.roomMatControl == '1') {
+          await _checkMat(barcodeContent.matCode, barcodeContent.batchNo);
+          await _checkMtlSite(
+            state.storeSite,
+            barcodeContent.batchNo,
+            barcodeContent.matCode,
+            matControl.toString(),
+          );
+        }
+        batchNo = barcodeContent.batchNo;
+        serialNumber = '';
+      } else {
+        throw Exception('物料$matCode控制属性非法');
+      }
+    }
+
+    for (final OutboundTaskItem item in state.taskItems) {
+      if (item.matCode == matCode) {
+        matInnerCode = item.matInnerCode;
+        matName = item.matName;
+        break;
+      }
+    }
+
+    final List<OutboundTaskItem> filtered = _queryTask(state.storeSite, matCode);
+
+    emit(state.copyWith(
+      matCode: matCode,
+      matInnerCode: matInnerCode,
+      matName: matName,
+      matSendControl: matSendControl,
+      matControlFlag: matControl.toString(),
+      sn: serialNumber,
+      batchNo: batchNo,
+      quantityInput: qty,
+      filteredItems: filtered,
+      errorMessage: null,
+    ));
+
+    await _checkInventory(0);
+  }
+  Future<void> _handleSiteBarcode(String barcode) async {
+    const String prefix = r'$KW$';
+    if (!barcode.startsWith(prefix) || barcode.length <= prefix.length) {
+      throw Exception('库位条码格式错误');
+    }
+    final String site = barcode.substring(prefix.length);
+    await repository.validateStoreSite(storeRoom: storeRoom, storeSite: site);
+    if ((state.matSendControl == '0' && state.roomMatControl == '0') ||
+        state.roomMatControl == '1') {
+      await _checkMtlSite(site, state.batchNo, state.matCode, state.matControlFlag);
+    }
+    final List<OutboundTaskItem> filtered = _queryTask(site, state.matCode);
+    emit(state.copyWith(
+      storeSite: site,
+      filteredItems: filtered,
+      errorMessage: null,
+    ));
+    await _checkInventory(0);
+  }
+  void _handleQuantity(String barcode) {
+    if (state.sn.isNotEmpty) {
+      throw Exception('序列号物料数量固定为1，请勿手动输入数量');
+    }
+    emit(state.copyWith(
+      quantityInput: double.parse(barcode),
+      errorMessage: null,
+    ));
+  }
+  String _buildMessage(String prefix) {
+    if (state.storeSite.isEmpty) {
+      return '$prefix请扫描库位';
+    }
+    if (state.sn.isEmpty && state.batchNo.isEmpty) {
+      return '$prefix请扫描条码';
+    }
+    if (state.quantityInput == null) {
+      return '$prefix请录入数量';
+    }
+    return prefix;
+  }
+  Future<void> _checkMat(String matCode, String batchNo) async {
+    for (final OutboundTaskItem item in state.taskItems) {
+      if (item.matCode == matCode &&
+          item.batchNo == batchNo &&
+          item.storeSite == state.storeSite) {
+        emit(state.copyWith(erpRoom: item.erpStore));
+        return;
+      }
+    }
+    for (final OutboundTaskItem item in state.taskItems) {
+      if (item.matCode == matCode && item.storeSite == state.storeSite) {
+        emit(state.copyWith(erpRoom: item.erpStore));
+        return;
+      }
+    }
+    throw Exception('明细中不存在物料$matCode');
+  }
+  Future<void> _checkMtlSite(
+    String siteCode,
+    String batch,
+    String matCode,
+    String matControl,
+  ) async {
+    if (matControl == '0') {
+      return;
+    }
+    if (matCode.isEmpty) {
+      return;
+    }
+    if (state.siteRequired && siteCode.isEmpty) {
+      return;
+    }
+    if (state.batchRequired && (matControl == '1' || matControl == '2') &&
+        batch.isEmpty) {
+      return;
+    }
+
+    if (state.siteRequired) {
+      for (final OutboundTaskItem item in state.taskItems) {
+        final bool matchBatch = state.batchRequired && (matControl == '1' || matControl == '2')
+            ? item.batchNo == batch
+            : true;
+        if (item.matCode == matCode && matchBatch && item.storeSite == siteCode) {
+          emit(state.copyWith(erpRoom: item.erpStore));
+          return;
+        }
+      }
+      if (state.batchRequired) {
+        throw Exception('物料$matCode批次$batch库位$siteCode不在明细中');
+      } else {
+        throw Exception('物料$matCode库位$siteCode不在明细中');
+      }
+    } else {
+      for (final OutboundTaskItem item in state.taskItems) {
+        final bool matchBatch = state.batchRequired && (matControl == '1' || matControl == '2')
+            ? item.batchNo == batch
+            : true;
+        if (item.matCode == matCode && matchBatch) {
+          emit(state.copyWith(erpRoom: item.erpStore));
+          return;
+        }
+      }
+      if (state.batchRequired) {
+        throw Exception('物料$matCode批次$batch不在明细中');
+      } else {
+        throw Exception('物料$matCode不在明细中');
+      }
+    }
+  }
+  Future<String> _checkInventory(double collectQty) async {
+    if (state.storeSite.isEmpty || state.matCode.isEmpty) {
+      return '';
+    }
+    final List<OutboundInventoryRecord> inventory =
+        await repository.fetchInventory(
+      storeSite: state.storeSite,
+      matCode: state.matCode,
+      batchNo: state.batchNo,
+      sn: state.sn,
+      erpStore: state.erpRoom,
+    );
+    double repQty = 0;
+    String key = '';
+    String erpStoreInv = '';
+
+    if (state.matControlFlag == '1' || state.matControlFlag == '2') {
+      key = '${state.storeSite}${state.matCode}${state.batchNo}';
+      final Iterable<OutboundInventoryRecord> matches = inventory.where((OutboundInventoryRecord record) {
+        final bool matchBatch = record.batchNo == state.batchNo;
+        final bool matchErp = state.erpRoom.isEmpty || record.erpStore == state.erpRoom;
+        return record.matCode == state.matCode && matchBatch && matchErp;
+      });
+      if (matches.isEmpty) {
+        throw Exception('物料${state.matCode}批次${state.batchNo}在库位${state.storeSite}不存在库存');
+      }
+      repQty = matches.fold<double>(0, (double sum, OutboundInventoryRecord record) => sum + record.quantity);
+      erpStoreInv = matches.first.erpStore;
+    } else {
+      key = '${state.storeSite}${state.matCode}${state.sn}';
+      final Iterable<OutboundInventoryRecord> matches = inventory.where((OutboundInventoryRecord record) {
+        final bool matchSn = record.sn == state.sn;
+        final bool matchErp = state.erpRoom.isEmpty || record.erpStore == state.erpRoom;
+        final bool matchBatch = state.batchNo.isEmpty || record.batchNo == state.batchNo;
+        return record.matCode == state.matCode && matchSn && matchErp && matchBatch;
+      });
+      if (matches.isEmpty) {
+        throw Exception('物料${state.matCode}批次${state.batchNo}序列号${state.sn}在库位${state.storeSite}不存在库存');
+      }
+      repQty = matches.fold<double>(0, (double sum, OutboundInventoryRecord record) => sum + record.quantity);
+      erpStoreInv = matches.first.erpStore;
+    }
+
+    if (state.erpRoom.isNotEmpty && erpStoreInv.isNotEmpty && state.erpRoom != erpStoreInv) {
+      throw Exception('明细指定ERP子库${state.erpRoom}与库存${erpStoreInv}不一致');
+    }
+
+    final double reserved = state.reservedInventory[key] ?? 0;
+    if (collectQty > 0 && repQty - reserved < collectQty) {
+      throw Exception('库位${state.storeSite}物料${state.matCode}可用数量${repQty - reserved}不足以采集${collectQty}');
+    }
+
+    emit(state.copyWith(
+      inventoryQty: repQty,
+      erpStoreInv: erpStoreInv,
+    ));
+    return key;
+  }
+  Future<void> _dealQuantity(double collectQty, String matFlag) async {
+    if (state.matControlFlag.isEmpty) {
+      throw Exception('未获取到物料控制属性');
+    }
+    if (collectQty <= 0) {
+      throw Exception('采集数量不能为0');
+    }
+
+    final String inventoryKey = await _checkInventory(collectQty);
+
+    double totalTaskQty = 0;
+    double totalCollectedQty = 0;
+    for (final OutboundTaskItem item in state.taskItems) {
+      if (item.matCode != state.matCode) {
+        continue;
+      }
+      bool match = true;
+      if ((matFlag == '1' || matFlag == '2') &&
+          ((state.matSendControl == '0' && state.roomMatControl == '0') ||
+              state.roomMatControl == '1')) {
+        if (state.checkMode == OutboundMtlCheckMode.mtlBatch) {
+          match = item.batchNo == state.batchNo;
+        } else if (state.checkMode == OutboundMtlCheckMode.mtlBatchSite) {
+          match = item.batchNo == state.batchNo && item.storeSite == state.storeSite;
+        } else if (state.checkMode == OutboundMtlCheckMode.mtlSite) {
+          match = item.storeSite == state.storeSite;
+        }
+      }
+      if (!match) {
+        continue;
+      }
+      totalTaskQty += item.hintQty;
+      totalCollectedQty += item.collectedQty;
+    }
+
+    if (totalCollectedQty + collectQty > totalTaskQty) {
+      throw Exception('采集数量$collectQty超过剩余可采集数量${totalTaskQty - totalCollectedQty}');
+    }
+
+    double remainingQty = collectQty;
+    final List<OutboundTaskItem> updatedItems = List<OutboundTaskItem>.from(state.taskItems);
+    final Map<String, OutboundCollectedSummary> summaries =
+        Map<String, OutboundCollectedSummary>.from(state.collectedSummary);
+    final Map<String, double> reservedInv =
+        Map<String, double>.from(state.reservedInventory);
+    final Map<String, String> dicSeq =
+        Map<String, String>.from(state.scannedSerials);
+    final Map<String, _OperationQuantities> operations = <String, _OperationQuantities>{};
+    bool matchedDetail = false;
+    double availableRepQty = state.inventoryQty ?? 0;
+
+    for (int i = 0; i < updatedItems.length; i++) {
+      if (remainingQty <= 0) {
+        break;
+      }
+      final OutboundTaskItem item = updatedItems[i];
+      if (item.matCode != state.matCode) {
+        continue;
+      }
+      if ((state.matSendControl == '0' && state.roomMatControl == '0') ||
+          state.roomMatControl == '1') {
+        if (matFlag == '1' || matFlag == '2') {
+          if (state.checkMode == OutboundMtlCheckMode.mtlBatch &&
+              item.batchNo != state.batchNo) {
+            continue;
+          }
+          if (state.checkMode == OutboundMtlCheckMode.mtlBatchSite &&
+              (item.batchNo != state.batchNo || item.storeSite != state.storeSite)) {
+            continue;
+          }
+          if (state.checkMode == OutboundMtlCheckMode.mtlSite &&
+              item.storeSite != state.storeSite) {
+            continue;
+          }
+        }
+      }
+
+      if (item.hintQty == item.collectedQty) {
+        continue;
+      }
+
+      matchedDetail = true;
+      final double available = item.hintQty - item.collectedQty;
+      final double consume = remainingQty >= available ? available : remainingQty;
+      remainingQty -= consume;
+
+      availableRepQty -= consume;
+      final double previousCollected = item.collectedQty;
+      final double newCollected = item.collectedQty + consume;
+      double newRep = item.repertoryQty - consume;
+      if (state.matControlFlag == '0') {
+        newRep = 0;
+      }
+
+      updatedItems[i] = item.copyWith(
+        collectedQty: newCollected,
+        repertoryQty: newRep,
+      );
+
+      final OutboundCollectedSummary summary = summaries[item.outTaskItemId] ??
+          OutboundCollectedSummary(
+            originalCollectedQty: previousCollected,
+            currentCollectedQty: previousCollected,
+            matCode: item.matCode,
+          );
+      summaries[item.outTaskItemId] = summary.copyWith(
+        currentCollectedQty: newCollected,
+      );
+
+      operations[item.outTaskItemId] = _OperationQuantities(
+        taskQty: item.hintQty,
+        collectedQty: consume,
+      );
+    }
+
+    if ((state.matSendControl == '0' && state.roomMatControl == '0') ||
+        state.roomMatControl == '1') {
+      if (!matchedDetail) {
+        throw Exception('采集信息未与明细匹配');
+      }
+    }
+
+    if (state.sn.isNotEmpty) {
+      dicSeq['${state.matCode}@${state.sn}'] = '${state.matCode}@${state.sn}';
+    }
+
+    final double currentReserved = reservedInv[inventoryKey] ?? 0;
+    reservedInv[inventoryKey] = currentReserved + collectQty;
+
+    final List<OutboundCollectionRecord> newRecords =
+        List<OutboundCollectionRecord>.from(state.collectionRecords);
+    for (final MapEntry<String, _OperationQuantities> entry in operations.entries) {
+      final OutboundTaskItem item = updatedItems.firstWhere(
+        (OutboundTaskItem element) => element.outTaskItemId == entry.key,
+      );
+      final OutboundCollectionRecord record = OutboundCollectionRecord(
+        matCode: state.matCode,
+        matName: state.matName,
+        batchNo: state.batchNo,
+        sn: state.sn,
+        collectQty: entry.value.collectedQty,
+        taskQty: entry.value.taskQty,
+        storeRoom: item.storeRoom,
+        storeSite: state.storeSite,
+        outTaskItemId: entry.key,
+        erpStore: state.erpStoreInv,
+        trayNo: item.trayNo,
+      );
+      newRecords.add(record);
+      final Box<OutboundCollectionRecord> box =
+          _localBox ??= await _localBoxFuture;
+      await box.add(record);
+    }
+
+    emit(state.copyWith(
+      taskItems: updatedItems,
+      filteredItems: _queryTask(state.storeSite, state.matCode, items: updatedItems),
+      collectedSummary: summaries,
+      reservedInventory: reservedInv,
+      collectionRecords: newRecords,
+      scannedSerials: dicSeq,
+      inventoryQty: availableRepQty,
+    ));
+  }
+  void _initializeCollect() {
+    emit(state.copyWith(
+      matCode: '',
+      matName: '',
+      matInnerCode: '',
+      batchNo: '',
+      sn: '',
+      quantityInput: null,
+      inventoryQty: 0,
+      erpStoreInv: '',
+      messageLabel: '请扫描库位',
+    ));
+  }
+  List<OutboundTaskItem> _queryTask(String barcode, String matCode,
+      {List<OutboundTaskItem>? items}) {
+    final Iterable<OutboundTaskItem> source = (items ?? state.taskItems);
+    return source.where((OutboundTaskItem item) {
+      final bool matchSite = barcode.isEmpty || item.storeSite == barcode;
+      final bool matchMat = matCode.isEmpty || item.matCode == matCode;
+      return matchSite && matchMat;
+    }).toList();
+  }
+  Future<void> _submitCollection() async {
+    if (state.collectionRecords.isEmpty) {
+      emit(state.copyWith(errorMessage: '没有采集明细，请先采集'));
+      return;
+    }
+
+    String msg = '';
+    for (final OutboundTaskItem item in state.taskItems) {
+      if (item.hintQty != item.collectedQty) {
+        msg = '库位${item.storeSite}物料${item.matCode}剩余${item.hintQty - item.collectedQty}未采集,是否提交?';
+        break;
+      }
+    }
+
+    if (msg.isNotEmpty) {
+      emit(state.copyWith(
+        pendingAction: OutboundPendingAction.commit,
+        pendingMessage: msg,
+      ));
+      return;
+    }
+
+    await _doCommit();
+  }
+
+  Future<void> _confirmPendingAction(bool confirmed) async {
+    if (!confirmed) {
+      emit(state.copyWith(
+        pendingAction: OutboundPendingAction.none,
+        pendingMessage: null,
+      ));
+      return;
+    }
+
+    switch (state.pendingAction) {
+      case OutboundPendingAction.commit:
+        await _doCommit();
+        break;
+      case OutboundPendingAction.close:
+        emit(state.copyWith(
+          shouldClose: true,
+          pendingAction: OutboundPendingAction.none,
+          pendingMessage: null,
+        ));
+        break;
+      case OutboundPendingAction.finish:
+        await _doFinishSelected();
+        break;
+      case OutboundPendingAction.none:
+        break;
+    }
+  }
+
+  Future<void> _doCommit() async {
+    emit(state.copyWith(isProcessing: true));
+    try {
+      final List<DownShelvesInfoPayload> downShelves = state.collectionRecords
+          .map(
+            (OutboundCollectionRecord record) => DownShelvesInfoPayload(
+              taskNo: taskNo,
+              matCode: record.matCode,
+              batchNo: record.batchNo,
+              sn: record.sn,
+              collectQty: record.collectQty,
+              storeRoomNo: record.storeRoom,
+              storeSiteNo: record.storeSite,
+              outTaskItemId: record.outTaskItemId,
+              erpStore: record.erpStore,
+              trayNo: record.trayNo,
+            ),
+          )
+          .toList();
+      final List<ItemListInfoPayload> itemList = state.collectedSummary.entries
+          .map(
+            (MapEntry<String, OutboundCollectedSummary> entry) =>
+                ItemListInfoPayload(
+                  outTaskItemId: entry.key,
+                  originalQty: entry.value.originalCollectedQty,
+                  collectedQty: entry.value.currentCollectedQty,
+                  matCode: entry.value.matCode,
+                ),
+          )
+          .toList();
+
+      for (final OutboundCollectionRecord record in state.collectionRecords) {
+        await repository.validateStoreSite(
+          storeRoom: record.storeRoom,
+          storeSite: record.storeSite,
+        );
+      }
+
+      await repository.commitDownShelves(
+        downShelves: downShelves,
+        items: itemList,
+        userId: userId,
+      );
+
+      final Box<OutboundCollectionRecord> box =
+          _localBox ??= await _localBoxFuture;
+      await box.clear();
+      await _initialize();
+      emit(state.copyWith(
+        isProcessing: false,
+        collectionRecords: <OutboundCollectionRecord>[],
+        collectedSummary: <String, OutboundCollectedSummary>{},
+        reservedInventory: <String, double>{},
+        scannedSerials: <String, String>{},
+        successMessage: '提交成功',
+        pendingAction: OutboundPendingAction.none,
+        pendingMessage: null,
+      ));
+    } catch (error) {
+      emit(state.copyWith(
+        isProcessing: false,
+        errorMessage: error.toString(),
+        pendingAction: OutboundPendingAction.none,
+        pendingMessage: null,
+      ));
+    }
+  }
+
+  void _requestClose() {
+    emit(state.copyWith(
+      pendingAction: OutboundPendingAction.close,
+      pendingMessage: '当前采集${state.collectionRecords.length}条,确认关闭?',
+    ));
+  }
+
+  void _toggleSelection(String outTaskItemId) {
+    final Set<String> selected = Set<String>.from(state.selectedItemIds);
+    if (selected.contains(outTaskItemId)) {
+      selected.remove(outTaskItemId);
+    } else {
+      selected.add(outTaskItemId);
+    }
+    emit(state.copyWith(selectedItemIds: selected));
+  }
+
+  Future<void> _finishSelected() async {
+    if (state.collectionRecords.isNotEmpty) {
+      emit(state.copyWith(errorMessage: '存在未提交的采集记录，无法标记完成'));
+      return;
+    }
+    if (state.selectedItemIds.isEmpty) {
+      emit(state.copyWith(errorMessage: '请先选择需要完成的明细'));
+      return;
+    }
+    emit(state.copyWith(
+      pendingAction: OutboundPendingAction.finish,
+      pendingMessage: '确认将选中明细标记为完成?',
+    ));
+  }
+
+  Future<void> _doFinishSelected() async {
+    emit(state.copyWith(isProcessing: true));
+    try {
+      for (final String id in state.selectedItemIds) {
+        await repository.commitFinishOutTaskItem(
+          outTaskItemId: id,
+          userId: userId,
+          roomTag: roomTag,
+        );
+      }
+      await _initialize();
+      emit(state.copyWith(
+        isProcessing: false,
+        selectedItemIds: <String>{},
+        successMessage: '完成成功',
+        pendingAction: OutboundPendingAction.none,
+        pendingMessage: null,
+      ));
+    } catch (error) {
+      emit(state.copyWith(
+        isProcessing: false,
+        errorMessage: error.toString(),
+        pendingAction: OutboundPendingAction.none,
+        pendingMessage: null,
+      ));
+    }
+  }
+
+  void _clearSuccessMessage() {
+    emit(state.copyWith(successMessage: null));
+  }
+
+  void _clearErrorMessage() {
+    if (state.errorMessage != null) {
+      emit(state.copyWith(errorMessage: null));
+    }
+  }
+
+  void _openCollectionDetail() {
+    emit(state.copyWith(
+      navigationTarget: OutboundNavigation.detail,
+      navigationArguments: <String, dynamic>{
+        'records': state.collectionRecords,
+      },
+    ));
+  }
+
+  void _openExceptionTask() {
+    if (state.collectionRecords.isNotEmpty) {
+      emit(state.copyWith(errorMessage: '采集未提交,请先提交后再登记异常'));
+      return;
+    }
+    emit(state.copyWith(
+      navigationTarget: OutboundNavigation.exception,
+      navigationArguments: <String, dynamic>{
+        'taskComment': taskComment,
+        'taskNo': taskNo,
+        'taskId': taskId,
+        'storeRoom': storeRoom,
+      },
+    ));
+  }
+
+  void _openSupplierTask() {
+    emit(state.copyWith(
+      navigationTarget: OutboundNavigation.supplier,
+      navigationArguments: <String, dynamic>{
+        'taskComment': taskComment,
+        'taskNo': taskNo,
+        'taskId': taskId,
+        'storeRoom': storeRoom,
+      },
+    ));
+  }
+
+  void _clearNavigation() {
+    emit(state.copyWith(navigationTarget: null, navigationArguments: null));
+  }
+
+  void _acknowledgeCloseHandled() {
+    if (state.shouldClose) {
+      emit(state.copyWith(shouldClose: false));
+    }
+  }

--- a/lib/modules/outbound/collection_task/bloc/outbound_collection_event.dart
+++ b/lib/modules/outbound/collection_task/bloc/outbound_collection_event.dart
@@ -1,0 +1,79 @@
+part of 'outbound_collection_bloc.dart';
+
+abstract class OutboundCollectionEvent extends Equatable {
+  const OutboundCollectionEvent();
+
+  @override
+  List<Object?> get props => const <Object?>[];
+}
+
+class _OutboundCollectionInitialized extends OutboundCollectionEvent {
+  const _OutboundCollectionInitialized();
+}
+
+class OutboundCollectionBarcodeScanned extends OutboundCollectionEvent {
+  const OutboundCollectionBarcodeScanned(this.raw);
+
+  final String raw;
+
+  @override
+  List<Object?> get props => <Object?>[raw];
+}
+
+class OutboundCollectionSubmitRequested extends OutboundCollectionEvent {
+  const OutboundCollectionSubmitRequested();
+}
+
+class OutboundCollectionPendingActionConfirmed extends OutboundCollectionEvent {
+  const OutboundCollectionPendingActionConfirmed(this.confirmed);
+
+  final bool confirmed;
+
+  @override
+  List<Object?> get props => <Object?>[confirmed];
+}
+
+class OutboundCollectionCloseRequested extends OutboundCollectionEvent {
+  const OutboundCollectionCloseRequested();
+}
+
+class OutboundCollectionSelectionToggled extends OutboundCollectionEvent {
+  const OutboundCollectionSelectionToggled(this.outTaskItemId);
+
+  final String outTaskItemId;
+
+  @override
+  List<Object?> get props => <Object?>[outTaskItemId];
+}
+
+class OutboundCollectionFinishSelected extends OutboundCollectionEvent {
+  const OutboundCollectionFinishSelected();
+}
+
+class OutboundCollectionSuccessCleared extends OutboundCollectionEvent {
+  const OutboundCollectionSuccessCleared();
+}
+
+class OutboundCollectionErrorCleared extends OutboundCollectionEvent {
+  const OutboundCollectionErrorCleared();
+}
+
+class OutboundCollectionDetailOpened extends OutboundCollectionEvent {
+  const OutboundCollectionDetailOpened();
+}
+
+class OutboundCollectionExceptionOpened extends OutboundCollectionEvent {
+  const OutboundCollectionExceptionOpened();
+}
+
+class OutboundCollectionSupplierOpened extends OutboundCollectionEvent {
+  const OutboundCollectionSupplierOpened();
+}
+
+class OutboundCollectionNavigationCleared extends OutboundCollectionEvent {
+  const OutboundCollectionNavigationCleared();
+}
+
+class OutboundCollectionCloseAcknowledged extends OutboundCollectionEvent {
+  const OutboundCollectionCloseAcknowledged();
+}

--- a/lib/modules/outbound/collection_task/bloc/outbound_collection_state.dart
+++ b/lib/modules/outbound/collection_task/bloc/outbound_collection_state.dart
@@ -1,0 +1,261 @@
+part of 'outbound_collection_bloc.dart';
+
+const Object _unset = Object();
+
+enum OutboundCollectionStatus { initial, loading, ready, failure }
+
+enum OutboundPendingAction { none, commit, close, finish }
+
+enum OutboundMtlCheckMode { mtl, mtlBatch, mtlSite, mtlBatchSite }
+
+enum OutboundNavigation { exception, supplier, detail }
+
+class OutboundCollectionState extends Equatable {
+  const OutboundCollectionState({
+    required this.status,
+    required this.taskItems,
+    required this.filteredItems,
+    required this.collectionRecords,
+    required this.collectedSummary,
+    required this.reservedInventory,
+    required this.scannedSerials,
+    required this.messageLabel,
+    required this.siteRequired,
+    required this.batchRequired,
+    required this.checkMode,
+    required this.storeRoom,
+    required this.storeSite,
+    required this.matCode,
+    required this.matName,
+    required this.matInnerCode,
+    required this.batchNo,
+    required this.sn,
+    required this.quantityInput,
+    required this.matControlFlag,
+    required this.matSendControl,
+    required this.erpRoom,
+    required this.erpStoreInv,
+    required this.inventoryQty,
+    required this.roomMatControl,
+    required this.errorMessage,
+    required this.successMessage,
+    required this.pendingAction,
+    required this.pendingMessage,
+    required this.selectedItemIds,
+    required this.shouldClose,
+    required this.isProcessing,
+    required this.navigationTarget,
+    required this.navigationArguments,
+  });
+
+  factory OutboundCollectionState.initial({
+    required String storeRoom,
+    required String siteFlag,
+    required String batchFlag,
+  }) {
+    final bool siteRequired = siteFlag == 'Y';
+    final bool batchRequired = batchFlag == 'Y';
+    OutboundMtlCheckMode mode = OutboundMtlCheckMode.mtl;
+    if (siteRequired && batchRequired) {
+      mode = OutboundMtlCheckMode.mtlBatchSite;
+    } else if (siteRequired) {
+      mode = OutboundMtlCheckMode.mtlSite;
+    } else if (batchRequired) {
+      mode = OutboundMtlCheckMode.mtlBatch;
+    }
+
+    return OutboundCollectionState(
+      status: OutboundCollectionStatus.initial,
+      taskItems: const <OutboundTaskItem>[],
+      filteredItems: const <OutboundTaskItem>[],
+      collectionRecords: const <OutboundCollectionRecord>[],
+      collectedSummary: const <String, OutboundCollectedSummary>{},
+      reservedInventory: const <String, double>{},
+      scannedSerials: const <String, String>{},
+      messageLabel: '请扫描库位',
+      siteRequired: siteRequired,
+      batchRequired: batchRequired,
+      checkMode: mode,
+      storeRoom: storeRoom,
+      storeSite: '',
+      matCode: '',
+      matName: '',
+      matInnerCode: '',
+      batchNo: '',
+      sn: '',
+      quantityInput: null,
+      matControlFlag: '',
+      matSendControl: '0',
+      erpRoom: '',
+      erpStoreInv: '',
+      inventoryQty: 0,
+      roomMatControl: '0',
+      errorMessage: null,
+      successMessage: null,
+      pendingAction: OutboundPendingAction.none,
+      pendingMessage: null,
+      selectedItemIds: const <String>{},
+      shouldClose: false,
+      isProcessing: false,
+      navigationTarget: null,
+      navigationArguments: null,
+    );
+  }
+
+  OutboundCollectionState copyWith({
+    OutboundCollectionStatus? status,
+    List<OutboundTaskItem>? taskItems,
+    List<OutboundTaskItem>? filteredItems,
+    List<OutboundCollectionRecord>? collectionRecords,
+    Map<String, OutboundCollectedSummary>? collectedSummary,
+    Map<String, double>? reservedInventory,
+    Map<String, String>? scannedSerials,
+    String? messageLabel,
+    bool? siteRequired,
+    bool? batchRequired,
+    OutboundMtlCheckMode? checkMode,
+    String? storeRoom,
+    String? storeSite,
+    String? matCode,
+    String? matName,
+    String? matInnerCode,
+    String? batchNo,
+    String? sn,
+    double? quantityInput,
+    String? matControlFlag,
+    String? matSendControl,
+    String? erpRoom,
+    String? erpStoreInv,
+    double? inventoryQty,
+    String? roomMatControl,
+    Object? errorMessage = _unset,
+    Object? successMessage = _unset,
+    OutboundPendingAction? pendingAction,
+    Object? pendingMessage = _unset,
+    Set<String>? selectedItemIds,
+    bool? shouldClose,
+    bool? isProcessing,
+    Object? navigationTarget = _unset,
+    Object? navigationArguments = _unset,
+  }) {
+    return OutboundCollectionState(
+      status: status ?? this.status,
+      taskItems: taskItems ?? this.taskItems,
+      filteredItems: filteredItems ?? this.filteredItems,
+      collectionRecords: collectionRecords ?? this.collectionRecords,
+      collectedSummary: collectedSummary ?? this.collectedSummary,
+      reservedInventory: reservedInventory ?? this.reservedInventory,
+      scannedSerials: scannedSerials ?? this.scannedSerials,
+      messageLabel: messageLabel ?? this.messageLabel,
+      siteRequired: siteRequired ?? this.siteRequired,
+      batchRequired: batchRequired ?? this.batchRequired,
+      checkMode: checkMode ?? this.checkMode,
+      storeRoom: storeRoom ?? this.storeRoom,
+      storeSite: storeSite ?? this.storeSite,
+      matCode: matCode ?? this.matCode,
+      matName: matName ?? this.matName,
+      matInnerCode: matInnerCode ?? this.matInnerCode,
+      batchNo: batchNo ?? this.batchNo,
+      sn: sn ?? this.sn,
+      quantityInput: quantityInput ?? this.quantityInput,
+      matControlFlag: matControlFlag ?? this.matControlFlag,
+      matSendControl: matSendControl ?? this.matSendControl,
+      erpRoom: erpRoom ?? this.erpRoom,
+      erpStoreInv: erpStoreInv ?? this.erpStoreInv,
+      inventoryQty: inventoryQty ?? this.inventoryQty,
+      roomMatControl: roomMatControl ?? this.roomMatControl,
+      errorMessage: identical(errorMessage, _unset)
+          ? this.errorMessage
+          : errorMessage as String?,
+      successMessage: identical(successMessage, _unset)
+          ? this.successMessage
+          : successMessage as String?,
+      pendingAction: pendingAction ?? this.pendingAction,
+      pendingMessage: identical(pendingMessage, _unset)
+          ? this.pendingMessage
+          : pendingMessage as String?,
+      selectedItemIds: selectedItemIds ?? this.selectedItemIds,
+      shouldClose: shouldClose ?? this.shouldClose,
+      isProcessing: isProcessing ?? this.isProcessing,
+      navigationTarget: identical(navigationTarget, _unset)
+          ? this.navigationTarget
+          : navigationTarget as OutboundNavigation?,
+      navigationArguments: identical(navigationArguments, _unset)
+          ? this.navigationArguments
+          : navigationArguments as Map<String, dynamic>?,
+    );
+  }
+
+  final OutboundCollectionStatus status;
+  final List<OutboundTaskItem> taskItems;
+  final List<OutboundTaskItem> filteredItems;
+  final List<OutboundCollectionRecord> collectionRecords;
+  final Map<String, OutboundCollectedSummary> collectedSummary;
+  final Map<String, double> reservedInventory;
+  final Map<String, String> scannedSerials;
+  final String messageLabel;
+  final bool siteRequired;
+  final bool batchRequired;
+  final OutboundMtlCheckMode checkMode;
+  final String storeRoom;
+  final String storeSite;
+  final String matCode;
+  final String matName;
+  final String matInnerCode;
+  final String batchNo;
+  final String sn;
+  final double? quantityInput;
+  final String matControlFlag;
+  final String matSendControl;
+  final String erpRoom;
+  final String erpStoreInv;
+  final double? inventoryQty;
+  final String roomMatControl;
+  final String? errorMessage;
+  final String? successMessage;
+  final OutboundPendingAction pendingAction;
+  final String? pendingMessage;
+  final Set<String> selectedItemIds;
+  final bool shouldClose;
+  final bool isProcessing;
+  final OutboundNavigation? navigationTarget;
+  final Map<String, dynamic>? navigationArguments;
+
+  @override
+  List<Object?> get props => <Object?>[
+        status,
+        taskItems,
+        filteredItems,
+        collectionRecords,
+        collectedSummary,
+        reservedInventory,
+        scannedSerials,
+        messageLabel,
+        siteRequired,
+        batchRequired,
+        checkMode,
+        storeRoom,
+        storeSite,
+        matCode,
+        matName,
+        matInnerCode,
+        batchNo,
+        sn,
+        quantityInput,
+        matControlFlag,
+        matSendControl,
+        erpRoom,
+        erpStoreInv,
+        inventoryQty,
+        roomMatControl,
+        errorMessage,
+        successMessage,
+        pendingAction,
+        pendingMessage,
+        selectedItemIds,
+        shouldClose,
+        isProcessing,
+        navigationTarget,
+        navigationArguments,
+      ];
+}

--- a/lib/modules/outbound/collection_task/models/barcode_content.dart
+++ b/lib/modules/outbound/collection_task/models/barcode_content.dart
@@ -1,0 +1,57 @@
+import 'package:equatable/equatable.dart';
+
+/// Parsed content from 2D barcode. Mirrors the PDA `BarcodeContent` entity.
+class BarcodeContent extends Equatable {
+  const BarcodeContent({
+    required this.matCode,
+    required this.batchNo,
+    required this.sn,
+    required this.packageQty,
+    required this.color,
+    required this.specificAttribute,
+    required this.drawCode,
+    required this.drawVersion,
+    required this.manufacturerCode,
+    required this.agentCode,
+  });
+
+  factory BarcodeContent.fromJson(Map<String, dynamic> json) {
+    return BarcodeContent(
+      matCode: (json['matcode'] ?? json['matCode'] ?? '').toString(),
+      batchNo: (json['batchno'] ?? json['batchNo'] ?? '').toString(),
+      sn: (json['sn'] ?? json['SN'] ?? '').toString(),
+      packageQty: (json['packageqty'] ?? json['packageQty'] ?? '').toString(),
+      color: (json['color'] ?? '').toString(),
+      specificAttribute: (json['specificAttribute'] ?? json['specificattribute'] ?? '').toString(),
+      drawCode: (json['drawCode'] ?? json['drawcode'] ?? '').toString(),
+      drawVersion: (json['drawVersion'] ?? json['drawversion'] ?? '').toString(),
+      manufacturerCode: (json['manufacturerCode'] ?? json['manufacturercode'] ?? '').toString(),
+      agentCode: (json['aagentCode'] ?? json['agentCode'] ?? json['aagentcode'] ?? '').toString(),
+    );
+  }
+
+  final String matCode;
+  final String batchNo;
+  final String sn;
+  final String packageQty;
+  final String color;
+  final String specificAttribute;
+  final String drawCode;
+  final String drawVersion;
+  final String manufacturerCode;
+  final String agentCode;
+
+  @override
+  List<Object?> get props => <Object?>[
+        matCode,
+        batchNo,
+        sn,
+        packageQty,
+        color,
+        specificAttribute,
+        drawCode,
+        drawVersion,
+        manufacturerCode,
+        agentCode,
+      ];
+}

--- a/lib/modules/outbound/collection_task/models/mat_control_info.dart
+++ b/lib/modules/outbound/collection_task/models/mat_control_info.dart
@@ -1,0 +1,34 @@
+import 'package:equatable/equatable.dart';
+
+/// Information returned by `/system/terminal/getMatControl`.
+class MatControlInfo extends Equatable {
+  const MatControlInfo({
+    required this.controlType,
+    required this.matId,
+    required this.sendControl,
+  });
+
+  factory MatControlInfo.fromRaw(String raw) {
+    final parts = raw.split('!');
+    final int control = parts.isNotEmpty && parts.first.trim().isNotEmpty
+        ? int.parse(parts.first.trim())
+        : 0;
+    final String id = parts.length > 3 ? parts[3] : '';
+    final String send = parts.length > 4 && parts[4].trim().isNotEmpty ? parts[4] : '0';
+    return MatControlInfo(controlType: control, matId: id, sendControl: send);
+  }
+
+  factory MatControlInfo.fromJson(Map<String, dynamic> json) {
+    final int control = int.tryParse((json['batchcontrol'] ?? json['controlType'] ?? '0').toString()) ?? 0;
+    final String id = (json['matid'] ?? json['matId'] ?? '').toString();
+    final String send = (json['sendcontrol'] ?? json['sendControl'] ?? json['matSendControl'] ?? '0').toString();
+    return MatControlInfo(controlType: control, matId: id, sendControl: send);
+  }
+
+  final int controlType; // 0: SN, 1: Batch, 2: Batch+Site
+  final String matId;
+  final String sendControl;
+
+  @override
+  List<Object?> get props => <Object?>[controlType, matId, sendControl];
+}

--- a/lib/modules/outbound/collection_task/models/outbound_collected_summary.dart
+++ b/lib/modules/outbound/collection_task/models/outbound_collected_summary.dart
@@ -1,0 +1,28 @@
+import 'package:equatable/equatable.dart';
+
+/// Mirrors the `dicMtlQty` structure in the PDA code.
+class OutboundCollectedSummary extends Equatable {
+  const OutboundCollectedSummary({
+    required this.originalCollectedQty,
+    required this.currentCollectedQty,
+    required this.matCode,
+  });
+
+  OutboundCollectedSummary copyWith({
+    double? originalCollectedQty,
+    double? currentCollectedQty,
+  }) {
+    return OutboundCollectedSummary(
+      originalCollectedQty: originalCollectedQty ?? this.originalCollectedQty,
+      currentCollectedQty: currentCollectedQty ?? this.currentCollectedQty,
+      matCode: matCode,
+    );
+  }
+
+  final double originalCollectedQty;
+  final double currentCollectedQty;
+  final String matCode;
+
+  @override
+  List<Object?> get props => <Object?>[originalCollectedQty, currentCollectedQty, matCode];
+}

--- a/lib/modules/outbound/collection_task/models/outbound_collection_record.dart
+++ b/lib/modules/outbound/collection_task/models/outbound_collection_record.dart
@@ -1,0 +1,69 @@
+import 'package:equatable/equatable.dart';
+import 'package:hive/hive.dart';
+
+part 'outbound_collection_record.g.dart';
+
+@HiveType(typeId: 41)
+class OutboundCollectionRecord extends HiveObject with EquatableMixin {
+  OutboundCollectionRecord({
+    required this.matCode,
+    required this.matName,
+    required this.batchNo,
+    required this.sn,
+    required this.collectQty,
+    required this.taskQty,
+    required this.storeRoom,
+    required this.storeSite,
+    required this.outTaskItemId,
+    required this.erpStore,
+    required this.trayNo,
+  });
+
+  @HiveField(0)
+  String matCode;
+
+  @HiveField(1)
+  String matName;
+
+  @HiveField(2)
+  String batchNo;
+
+  @HiveField(3)
+  String sn;
+
+  @HiveField(4)
+  double collectQty;
+
+  @HiveField(5)
+  double taskQty;
+
+  @HiveField(6)
+  String storeRoom;
+
+  @HiveField(7)
+  String storeSite;
+
+  @HiveField(8)
+  String outTaskItemId;
+
+  @HiveField(9)
+  String erpStore;
+
+  @HiveField(10)
+  String trayNo;
+
+  @override
+  List<Object?> get props => <Object?>[
+        matCode,
+        matName,
+        batchNo,
+        sn,
+        collectQty,
+        taskQty,
+        storeRoom,
+        storeSite,
+        outTaskItemId,
+        erpStore,
+        trayNo,
+      ];
+}

--- a/lib/modules/outbound/collection_task/models/outbound_collection_record.g.dart
+++ b/lib/modules/outbound/collection_task/models/outbound_collection_record.g.dart
@@ -1,0 +1,59 @@
+// GENERATED CODE - MANUAL IMPLEMENTATION
+
+part of 'outbound_collection_record.dart';
+
+class OutboundCollectionRecordAdapter extends TypeAdapter<OutboundCollectionRecord> {
+  @override
+  final int typeId = 41;
+
+  @override
+  OutboundCollectionRecord read(BinaryReader reader) {
+    final fields = <int, dynamic>{};
+    final fieldCount = reader.readByte();
+    for (var i = 0; i < fieldCount; i++) {
+      final key = reader.readByte();
+      fields[key] = reader.read();
+    }
+    return OutboundCollectionRecord(
+      matCode: fields[0] as String,
+      matName: fields[1] as String,
+      batchNo: fields[2] as String,
+      sn: fields[3] as String,
+      collectQty: (fields[4] as num).toDouble(),
+      taskQty: (fields[5] as num).toDouble(),
+      storeRoom: fields[6] as String,
+      storeSite: fields[7] as String,
+      outTaskItemId: fields[8] as String,
+      erpStore: fields[9] as String,
+      trayNo: fields[10] as String,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, OutboundCollectionRecord obj) {
+    writer
+      ..writeByte(11)
+      ..writeByte(0)
+      ..write(obj.matCode)
+      ..writeByte(1)
+      ..write(obj.matName)
+      ..writeByte(2)
+      ..write(obj.batchNo)
+      ..writeByte(3)
+      ..write(obj.sn)
+      ..writeByte(4)
+      ..write(obj.collectQty)
+      ..writeByte(5)
+      ..write(obj.taskQty)
+      ..writeByte(6)
+      ..write(obj.storeRoom)
+      ..writeByte(7)
+      ..write(obj.storeSite)
+      ..writeByte(8)
+      ..write(obj.outTaskItemId)
+      ..writeByte(9)
+      ..write(obj.erpStore)
+      ..writeByte(10)
+      ..write(obj.trayNo);
+  }
+}

--- a/lib/modules/outbound/collection_task/models/outbound_collection_repository.dart
+++ b/lib/modules/outbound/collection_task/models/outbound_collection_repository.dart
@@ -1,0 +1,177 @@
+import 'dart:async';
+
+import 'package:dio/dio.dart';
+import 'package:hive/hive.dart';
+
+import 'barcode_content.dart';
+import 'mat_control_info.dart';
+import 'outbound_collection_record.dart';
+import 'outbound_down_shelves_payload.dart';
+import 'outbound_inventory_record.dart';
+import 'outbound_task_item.dart';
+
+class OutboundCollectionRepository {
+  OutboundCollectionRepository(this._dio);
+
+  final Dio _dio;
+
+  Future<List<OutboundTaskItem>> fetchTaskItems({
+    required String taskNo,
+    required String userId,
+    required String roleId,
+    required String workStation,
+    required String roomTag,
+    required String taskComment,
+  }) async {
+    final response = await _dio.get<Map<String, dynamic>>(
+      '/system/terminal/outTaskitemList',
+      queryParameters: <String, dynamic>{
+        'outtaskid': taskNo,
+        'userId': userId,
+        'roleoRuserId': roleId,
+        'workstation': workStation,
+        'roomTag': roomTag,
+        'searchKey': taskComment,
+        'PageIndex': '1',
+        'PageSize': '500',
+        'batchflag': '0',
+        'transferType': '0',
+        'beatflag': 'N',
+      },
+    );
+    final List<dynamic> rows =
+        response.data?['data']?['rows'] as List<dynamic>? ?? <dynamic>[];
+    return rows
+        .map((dynamic e) => OutboundTaskItem.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  Future<String> getRoomMatControl(String taskId) async {
+    final response = await _dio.get<Map<String, dynamic>>(
+      '/system/terminal/getRoomMatControl',
+      queryParameters: <String, dynamic>{'taskId': taskId},
+    );
+    final data = response.data?['data'];
+    if (data is Map<String, dynamic>) {
+      return (data['matcontrol'] ?? data['roomMatControl'] ?? '0').toString();
+    }
+    final raw = response.data?['msg']?.toString() ?? '0';
+    return raw.split('!').length > 4 ? raw.split('!')[4] : '0';
+  }
+
+  Future<MatControlInfo> getMatControl(String matCode) async {
+    final response = await _dio.get<Map<String, dynamic>>(
+      '/system/terminal/getMatControl',
+      queryParameters: <String, dynamic>{'matCode': matCode},
+    );
+    final data = response.data?['data'];
+    if (data is Map<String, dynamic>) {
+      return MatControlInfo.fromJson(data);
+    }
+    final raw = response.data?['msg']?.toString() ?? '';
+    return MatControlInfo.fromRaw(raw);
+  }
+
+  Future<BarcodeContent> analysisBarcode(String barcode) async {
+    final response = await _dio.get<Map<String, dynamic>>(
+      '/system/terminal/analysisBarcode',
+      queryParameters: <String, dynamic>{'barcode': barcode},
+    );
+    final data = response.data?['data'];
+    if (data is Map<String, dynamic>) {
+      return BarcodeContent.fromJson(data);
+    }
+    throw DioException(
+      requestOptions: response.requestOptions,
+      error: '条码解析失败',
+    );
+  }
+
+  Future<void> validateStoreSite({
+    required String storeRoom,
+    required String storeSite,
+  }) async {
+    final response = await _dio.get<Map<String, dynamic>>(
+      '/system/terminal/getStoreSite',
+      queryParameters: <String, dynamic>{
+        'storeRoomNo': storeRoom,
+        'storeSiteNo': storeSite,
+      },
+    );
+    if (response.data == null || response.data?['code'] != 200) {
+      throw DioException(
+        requestOptions: response.requestOptions,
+        error: response.data?['msg'] ?? '库位校验失败',
+      );
+    }
+    final status = response.data?['data']?['status']?.toString();
+    if (status != null && status != '0') {
+      throw DioException(
+        requestOptions: response.requestOptions,
+        error: '库位$storeSite已冻结',
+      );
+    }
+  }
+
+  Future<List<OutboundInventoryRecord>> fetchInventory({
+    required String storeSite,
+    required String matCode,
+    String batchNo = '',
+    String sn = '',
+    String erpStore = '',
+  }) async {
+    final response = await _dio.get<Map<String, dynamic>>(
+      '/system/terminal/getRepertoryByStoresiteNo',
+      queryParameters: <String, dynamic>{
+        'storesiteno': storeSite,
+        'matcode': matCode,
+        'batchno': batchNo,
+        'sn': sn,
+        'erpStoreroom': erpStore,
+      },
+    );
+    final List<dynamic> rows = response.data?['data'] is List
+        ? response.data?['data'] as List<dynamic>
+        : response.data?['data']?['rows'] as List<dynamic>? ?? <dynamic>[];
+    return rows
+        .map((dynamic e) =>
+            OutboundInventoryRecord.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  Future<void> commitDownShelves({
+    required List<DownShelvesInfoPayload> downShelves,
+    required List<ItemListInfoPayload> items,
+    required String userId,
+  }) async {
+    await _dio.post<void>(
+      '/system/terminal/commitDownShelves',
+      data: <String, dynamic>{
+        'downShelvesInfos': downShelves.map((e) => e.toJson()).toList(),
+        'itemListInfos': items.map((e) => e.toJson()).toList(),
+        'userId': userId,
+      },
+    );
+  }
+
+  Future<void> commitFinishOutTaskItem({
+    required String outTaskItemId,
+    required String userId,
+    required String roomTag,
+  }) async {
+    await _dio.post<void>(
+      '/system/terminal/commitFinishOutTaskItem',
+      data: <String, dynamic>{
+        'outtaskitemid': outTaskItemId,
+        'userId': userId,
+        'roomTag': roomTag,
+        'isCanel': false,
+      },
+    );
+  }
+
+  Future<List<OutboundCollectionRecord>> loadLocalCollections(
+      Box<OutboundCollectionRecord> box) async {
+    return box.values.toList();
+  }
+}

--- a/lib/modules/outbound/collection_task/models/outbound_down_shelves_payload.dart
+++ b/lib/modules/outbound/collection_task/models/outbound_down_shelves_payload.dart
@@ -1,0 +1,81 @@
+import 'package:equatable/equatable.dart';
+
+class DownShelvesInfoPayload extends Equatable {
+  const DownShelvesInfoPayload({
+    required this.taskNo,
+    required this.matCode,
+    required this.batchNo,
+    required this.sn,
+    required this.collectQty,
+    required this.storeRoomNo,
+    required this.storeSiteNo,
+    required this.outTaskItemId,
+    required this.erpStore,
+    required this.trayNo,
+  });
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'outtaskid': taskNo,
+      'matcode': matCode,
+      'batchno': batchNo,
+      'sn': sn,
+      'quantity': collectQty,
+      'storeroomno': storeRoomNo,
+      'storesiteno': storeSiteNo,
+      'outtaskitemid': outTaskItemId,
+      'erpstoreroom': erpStore,
+      'palletno': trayNo,
+    };
+  }
+
+  final String taskNo;
+  final String matCode;
+  final String batchNo;
+  final String sn;
+  final double collectQty;
+  final String storeRoomNo;
+  final String storeSiteNo;
+  final String outTaskItemId;
+  final String erpStore;
+  final String trayNo;
+
+  @override
+  List<Object?> get props => <Object?>[
+        taskNo,
+        matCode,
+        batchNo,
+        sn,
+        collectQty,
+        storeRoomNo,
+        storeSiteNo,
+        outTaskItemId,
+        erpStore,
+        trayNo,
+      ];
+}
+
+class ItemListInfoPayload extends Equatable {
+  const ItemListInfoPayload({
+    required this.outTaskItemId,
+    required this.originalQty,
+    required this.collectedQty,
+    required this.matCode,
+  });
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'outtaskitemid': outTaskItemId,
+      'quantity': <String>[originalQty.toString(), collectedQty.toString()],
+      'matcode': matCode,
+    };
+  }
+
+  final String outTaskItemId;
+  final double originalQty;
+  final double collectedQty;
+  final String matCode;
+
+  @override
+  List<Object?> get props => <Object?>[outTaskItemId, originalQty, collectedQty, matCode];
+}

--- a/lib/modules/outbound/collection_task/models/outbound_inventory_record.dart
+++ b/lib/modules/outbound/collection_task/models/outbound_inventory_record.dart
@@ -1,0 +1,40 @@
+import 'package:equatable/equatable.dart';
+
+class OutboundInventoryRecord extends Equatable {
+  const OutboundInventoryRecord({
+    required this.storeSite,
+    required this.matCode,
+    required this.batchNo,
+    required this.sn,
+    required this.erpStore,
+    required this.quantity,
+  });
+
+  factory OutboundInventoryRecord.fromJson(Map<String, dynamic> json) {
+    double parseQty(dynamic value) {
+      if (value == null || value.toString().trim().isEmpty) {
+        return 0;
+      }
+      return double.tryParse(value.toString()) ?? 0;
+    }
+
+    return OutboundInventoryRecord(
+      storeSite: (json['storesiteno'] ?? json['storeSiteNo'] ?? '').toString(),
+      matCode: (json['matcode'] ?? json['matCode'] ?? '').toString(),
+      batchNo: (json['batchno'] ?? json['batchNo'] ?? '').toString(),
+      sn: (json['sn'] ?? '').toString(),
+      erpStore: (json['erp_storeroom'] ?? json['erpStore'] ?? json['erpStoreroom'] ?? '').toString(),
+      quantity: parseQty(json['quantity'] ?? json['repqty'] ?? json['qty']),
+    );
+  }
+
+  final String storeSite;
+  final String matCode;
+  final String batchNo;
+  final String sn;
+  final String erpStore;
+  final double quantity;
+
+  @override
+  List<Object?> get props => <Object?>[storeSite, matCode, batchNo, sn, erpStore, quantity];
+}

--- a/lib/modules/outbound/collection_task/models/outbound_task_item.dart
+++ b/lib/modules/outbound/collection_task/models/outbound_task_item.dart
@@ -1,0 +1,103 @@
+import 'package:equatable/equatable.dart';
+
+class OutboundTaskItem extends Equatable {
+  const OutboundTaskItem({
+    required this.outTaskItemId,
+    required this.matCode,
+    required this.matName,
+    required this.storeSite,
+    required this.storeRoom,
+    required this.hintQty,
+    required this.collectedQty,
+    required this.repertoryQty,
+    required this.batchNo,
+    required this.sn,
+    required this.erpStore,
+    required this.orderNo,
+    required this.matInnerCode,
+    required this.trayNo,
+  });
+
+  factory OutboundTaskItem.fromJson(Map<String, dynamic> json) {
+    double parseDouble(dynamic value) {
+      if (value == null || value.toString().isEmpty) {
+        return 0;
+      }
+      return double.tryParse(value.toString()) ?? 0;
+    }
+
+    return OutboundTaskItem(
+      outTaskItemId: (json['outtaskitemid'] ?? json['outTaskItemId'] ?? '').toString(),
+      matCode: (json['matcode'] ?? json['matCode'] ?? '').toString(),
+      matName: (json['matname'] ?? json['matName'] ?? '').toString(),
+      storeSite: (json['storesiteno'] ?? json['storeSiteNo'] ?? '').toString(),
+      storeRoom: (json['storeroomno'] ?? json['storeRoomNo'] ?? '').toString(),
+      hintQty: parseDouble(json['quantity'] ?? json['hintqty'] ?? json['taskQty']),
+      collectedQty: parseDouble(json['collectedqty'] ?? json['collectQty'] ?? json['collectedQty']),
+      repertoryQty: parseDouble(json['repqty'] ?? json['repertoryQty'] ?? 0),
+      batchNo: (json['batchno'] ?? json['batchNo'] ?? '').toString(),
+      sn: (json['sn'] ?? '').toString(),
+      erpStore: (json['erp_storeroom'] ?? json['erpStore'] ?? json['erpStoreroom'] ?? '').toString(),
+      orderNo: (json['orderno'] ?? json['orderNo'] ?? '').toString(),
+      matInnerCode: (json['matinnercode'] ?? json['matInnerCode'] ?? '').toString(),
+      trayNo: (json['palletno'] ?? json['trayNo'] ?? '').toString(),
+    );
+  }
+
+  OutboundTaskItem copyWith({
+    double? hintQty,
+    double? collectedQty,
+    double? repertoryQty,
+    String? storeSite,
+  }) {
+    return OutboundTaskItem(
+      outTaskItemId: outTaskItemId,
+      matCode: matCode,
+      matName: matName,
+      storeSite: storeSite ?? this.storeSite,
+      storeRoom: storeRoom,
+      hintQty: hintQty ?? this.hintQty,
+      collectedQty: collectedQty ?? this.collectedQty,
+      repertoryQty: repertoryQty ?? this.repertoryQty,
+      batchNo: batchNo,
+      sn: sn,
+      erpStore: erpStore,
+      orderNo: orderNo,
+      matInnerCode: matInnerCode,
+      trayNo: trayNo,
+    );
+  }
+
+  final String outTaskItemId;
+  final String matCode;
+  final String matName;
+  final String storeSite;
+  final String storeRoom;
+  final double hintQty;
+  final double collectedQty;
+  final double repertoryQty;
+  final String batchNo;
+  final String sn;
+  final String erpStore;
+  final String orderNo;
+  final String matInnerCode;
+  final String trayNo;
+
+  @override
+  List<Object?> get props => <Object?>[
+        outTaskItemId,
+        matCode,
+        matName,
+        storeSite,
+        storeRoom,
+        hintQty,
+        collectedQty,
+        repertoryQty,
+        batchNo,
+        sn,
+        erpStore,
+        orderNo,
+        matInnerCode,
+        trayNo,
+      ];
+}

--- a/lib/modules/outbound/collection_task/outbound_collection_module.dart
+++ b/lib/modules/outbound/collection_task/outbound_collection_module.dart
@@ -1,0 +1,106 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+import 'models/outbound_collection_record.dart';
+import 'models/outbound_collection_repository.dart';
+import 'outbound_collection_page.dart';
+
+class OutboundCollectionModule extends Module {
+  @override
+  List<Bind<Object>> get binds => <Bind<Object>>[
+        Bind.singleton<Dio>(
+          (i) => Dio(
+            BaseOptions(
+              baseUrl: 'http://10.12.8.123:8086',
+              connectTimeout: const Duration(seconds: 30),
+              receiveTimeout: const Duration(seconds: 30),
+            ),
+          ),
+        ),
+        Bind.singleton<OutboundCollectionRepository>(
+          (i) => OutboundCollectionRepository(i<Dio>()),
+        ),
+        AsyncBind<Box<OutboundCollectionRecord>>((i) async {
+          try {
+            await Hive.initFlutter();
+          } catch (_) {
+            // already initialized
+          }
+          if (!Hive.isAdapterRegistered(OutboundCollectionRecordAdapter().typeId)) {
+            Hive.registerAdapter(OutboundCollectionRecordAdapter());
+          }
+          if (Hive.isBoxOpen('outbound_collection')) {
+            return Hive.box<OutboundCollectionRecord>('outbound_collection');
+          }
+          return Hive.openBox<OutboundCollectionRecord>('outbound_collection');
+        }),
+      ];
+
+  @override
+  List<ModularRoute> get routes => <ModularRoute>[
+        ChildRoute(
+          Modular.initialRoute,
+          child: (_, args) {
+            final Map<String, dynamic> data = args.data as Map<String, dynamic>? ?? <String, dynamic>{};
+            return OutboundCollectionPage(
+              taskNo: data['taskNo']?.toString() ?? '',
+              taskId: data['taskId']?.toString() ?? '',
+              storeRoom: data['storeRoom']?.toString() ?? '',
+              siteFlag: data['siteFlag']?.toString() ?? 'Y',
+              batchFlag: data['batchFlag']?.toString() ?? 'Y',
+              taskComment: data['taskComment']?.toString() ?? '',
+              workStation: data['workStation']?.toString() ?? '',
+              userId: data['userId']?.toString() ?? '',
+              roleId: data['roleId']?.toString() ?? '',
+              roomTag: data['roomTag']?.toString() ?? '0',
+            );
+          },
+        ),
+        ChildRoute(
+          '/detail',
+          child: (_, args) {
+            final Map<String, dynamic> data = args.data as Map<String, dynamic>? ?? <String, dynamic>{};
+            final List<OutboundCollectionRecord> records =
+                (data['records'] as List<OutboundCollectionRecord>? ?? <OutboundCollectionRecord>[]);
+            return Scaffold(
+              appBar: AppBar(title: const Text('采集明细列表')),
+              body: ListView.builder(
+                itemCount: records.length,
+                itemBuilder: (_, int index) => ListTile(
+                  title: Text('${records[index].matCode} 批次:${records[index].batchNo}'),
+                  subtitle: Text('数量:${records[index].collectQty} 库位:${records[index].storeSite}'),
+                ),
+              ),
+            );
+          },
+        ),
+        ChildRoute(
+          '/exception',
+          child: (_, args) {
+            final Map<String, dynamic> data = args.data as Map<String, dynamic>? ?? <String, dynamic>{};
+            return Scaffold(
+              appBar: AppBar(title: const Text('异常登记')),
+              body: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Text('任务:${data['taskNo'] ?? ''} 库房:${data['storeRoom'] ?? ''}'),
+              ),
+            );
+          },
+        ),
+        ChildRoute(
+          '/supplier',
+          child: (_, args) {
+            final Map<String, dynamic> data = args.data as Map<String, dynamic>? ?? <String, dynamic>{};
+            return Scaffold(
+              appBar: AppBar(title: const Text('供应商任务')),
+              body: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Text('任务:${data['taskNo'] ?? ''} 库房:${data['storeRoom'] ?? ''}'),
+              ),
+            );
+          },
+        ),
+      ];
+}

--- a/lib/modules/outbound/collection_task/outbound_collection_page.dart
+++ b/lib/modules/outbound/collection_task/outbound_collection_page.dart
@@ -1,0 +1,392 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:hive/hive.dart';
+
+import 'bloc/outbound_collection_bloc.dart';
+import 'models/outbound_collection_record.dart';
+import 'models/outbound_collection_repository.dart';
+import 'models/outbound_task_item.dart';
+import 'widgets/collection_record_tile.dart';
+import 'widgets/task_item_tile.dart';
+
+class OutboundCollectionPage extends StatelessWidget {
+  const OutboundCollectionPage({
+    super.key,
+    required this.taskNo,
+    required this.taskId,
+    required this.storeRoom,
+    required this.siteFlag,
+    required this.batchFlag,
+    required this.taskComment,
+    required this.workStation,
+    required this.userId,
+    required this.roleId,
+    required this.roomTag,
+  });
+
+  final String taskNo;
+  final String taskId;
+  final String storeRoom;
+  final String siteFlag;
+  final String batchFlag;
+  final String taskComment;
+  final String workStation;
+  final String userId;
+  final String roleId;
+  final String roomTag;
+
+  @override
+  Widget build(BuildContext context) {
+    final OutboundCollectionRepository repository =
+        Modular.get<OutboundCollectionRepository>();
+    final Future<Box<OutboundCollectionRecord>> localBox =
+        Modular.getAsync<Box<OutboundCollectionRecord>>();
+
+    return BlocProvider<OutboundCollectionBloc>(
+      create: (_) => OutboundCollectionBloc(
+        repository: repository,
+        taskNo: taskNo,
+        taskId: taskId,
+        taskComment: taskComment,
+        workStation: workStation,
+        storeRoom: storeRoom,
+        siteFlag: siteFlag,
+        batchFlag: batchFlag,
+        userId: userId,
+        roleId: roleId,
+        roomTag: roomTag,
+        localBox: localBox,
+      ),
+      child: const _OutboundCollectionView(),
+    );
+  }
+}
+
+class _OutboundCollectionView extends StatefulWidget {
+  const _OutboundCollectionView();
+
+  @override
+  State<_OutboundCollectionView> createState() => _OutboundCollectionViewState();
+}
+
+class _OutboundCollectionViewState extends State<_OutboundCollectionView> {
+  late final TextEditingController _barcodeController;
+  late final FocusNode _barcodeFocus;
+
+  @override
+  void initState() {
+    super.initState();
+    _barcodeController = TextEditingController();
+    _barcodeFocus = FocusNode();
+  }
+
+  @override
+  void dispose() {
+    _barcodeController.dispose();
+    _barcodeFocus.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<OutboundCollectionBloc, OutboundCollectionState>(
+      listenWhen: (OutboundCollectionState previous, OutboundCollectionState current) =>
+          previous.errorMessage != current.errorMessage ||
+          previous.successMessage != current.successMessage ||
+          previous.pendingAction != current.pendingAction ||
+          previous.shouldClose != current.shouldClose ||
+          previous.navigationTarget != current.navigationTarget,
+      listener: (BuildContext context, OutboundCollectionState state) async {
+        final messenger = ScaffoldMessenger.of(context);
+        if (state.errorMessage != null) {
+          messenger.showSnackBar(
+            SnackBar(content: Text(state.errorMessage!)),
+          );
+          context
+              .read<OutboundCollectionBloc>()
+              .add(const OutboundCollectionErrorCleared());
+        }
+        if (state.successMessage != null) {
+          messenger.showSnackBar(
+            SnackBar(content: Text(state.successMessage!)),
+          );
+          context
+              .read<OutboundCollectionBloc>()
+              .add(const OutboundCollectionSuccessCleared());
+        }
+        if (state.pendingAction != OutboundPendingAction.none &&
+            state.pendingMessage != null) {
+          final bool? confirmed = await showDialog<bool>(
+            context: context,
+            builder: (BuildContext context) {
+              return AlertDialog(
+                title: const Text('确认操作'),
+                content: Text(state.pendingMessage!),
+                actions: <Widget>[
+                  TextButton(
+                    onPressed: () => Navigator.of(context).pop(false),
+                    child: const Text('取消'),
+                  ),
+                  ElevatedButton(
+                    onPressed: () => Navigator.of(context).pop(true),
+                    child: const Text('确定'),
+                  ),
+                ],
+              );
+            },
+          );
+          if (!mounted) return;
+          context.read<OutboundCollectionBloc>().add(
+                OutboundCollectionPendingActionConfirmed(confirmed ?? false),
+              );
+        }
+        if (state.shouldClose) {
+          if (Navigator.of(context).canPop()) {
+            Navigator.of(context).pop();
+          }
+          if (!mounted) return;
+          context
+              .read<OutboundCollectionBloc>()
+              .add(const OutboundCollectionCloseAcknowledged());
+        }
+        if (state.navigationTarget != null) {
+          switch (state.navigationTarget!) {
+            case OutboundNavigation.detail:
+              Modular.to.pushNamed('./detail', arguments: state.navigationArguments);
+              break;
+            case OutboundNavigation.exception:
+              Modular.to.pushNamed('./exception', arguments: state.navigationArguments);
+              break;
+            case OutboundNavigation.supplier:
+              Modular.to.pushNamed('./supplier', arguments: state.navigationArguments);
+              break;
+          }
+          if (!mounted) return;
+          context
+              .read<OutboundCollectionBloc>()
+              .add(const OutboundCollectionNavigationCleared());
+        }
+      },
+      child: BlocBuilder<OutboundCollectionBloc, OutboundCollectionState>(
+        builder: (BuildContext context, OutboundCollectionState state) {
+          if (state.status == OutboundCollectionStatus.loading ||
+              state.status == OutboundCollectionStatus.initial) {
+            return const Scaffold(
+              body: Center(child: CircularProgressIndicator()),
+            );
+          }
+          if (state.status == OutboundCollectionStatus.failure) {
+            return Scaffold(
+              appBar: AppBar(title: const Text('出库采集')),
+              body: Center(child: Text(state.errorMessage ?? '加载失败')),
+            );
+          }
+
+          final bloc = context.read<OutboundCollectionBloc>();
+
+          return Scaffold(
+            appBar: AppBar(title: const Text('出库采集任务')),
+            body: Column(
+              children: <Widget>[
+                if (state.isProcessing)
+                  const LinearProgressIndicator(minHeight: 2),
+                Padding(
+                  padding: const EdgeInsets.all(12),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      Text(state.messageLabel,
+                          style: Theme.of(context).textTheme.titleMedium),
+                      const SizedBox(height: 8),
+                      Wrap(
+                        spacing: 12,
+                        runSpacing: 8,
+                        children: <Widget>[
+                          _InfoChip(label: '库位', value: state.storeSite),
+                          _InfoChip(label: '物料', value: state.matCode),
+                          _InfoChip(label: '名称', value: state.matName),
+                          _InfoChip(label: '批次', value: state.batchNo),
+                          _InfoChip(label: '序列', value: state.sn),
+                          _InfoChip(
+                            label: '数量',
+                            value: state.quantityInput?.toString() ?? '',
+                          ),
+                          _InfoChip(
+                            label: '可用库存',
+                            value: state.inventoryQty?.toString() ?? '',
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 12),
+                  child: Row(
+                    children: <Widget>[
+                      Expanded(
+                        child: TextField(
+                          controller: _barcodeController,
+                          focusNode: _barcodeFocus,
+                          decoration: const InputDecoration(
+                            labelText: '扫描条码/库位/数量',
+                          ),
+                          onSubmitted: (String value) {
+                            if (value.isNotEmpty) {
+                              bloc.add(
+                                  OutboundCollectionBarcodeScanned(value));
+                              _barcodeController.clear();
+                              _barcodeFocus.requestFocus();
+                            }
+                          },
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      ElevatedButton(
+                        onPressed: () {
+                          final String value = _barcodeController.text.trim();
+                          if (value.isNotEmpty) {
+                            bloc.add(OutboundCollectionBarcodeScanned(value));
+                            _barcodeController.clear();
+                            _barcodeFocus.requestFocus();
+                          }
+                        },
+                        child: const Text('确定'),
+                      ),
+                    ],
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                  child: Wrap(
+                    spacing: 12,
+                    runSpacing: 8,
+                    children: <Widget>[
+                      ElevatedButton(
+                        onPressed: () => bloc
+                            .add(const OutboundCollectionSubmitRequested()),
+                        child: const Text('提交采集'),
+                      ),
+                      OutlinedButton(
+                        onPressed: () => bloc
+                            .add(const OutboundCollectionDetailOpened()),
+                        child: const Text('采集明细'),
+                      ),
+                      OutlinedButton(
+                        onPressed: () =>
+                            bloc.add(const OutboundCollectionFinishSelected()),
+                        child: const Text('完成选中'),
+                      ),
+                      OutlinedButton(
+                        onPressed: () =>
+                            bloc.add(const OutboundCollectionExceptionOpened()),
+                        child: const Text('异常登记'),
+                      ),
+                      OutlinedButton(
+                        onPressed: () =>
+                            bloc.add(const OutboundCollectionSupplierOpened()),
+                        child: const Text('供应商任务'),
+                      ),
+                      OutlinedButton(
+                        onPressed: () =>
+                            bloc.add(const OutboundCollectionCloseRequested()),
+                        child: const Text('关闭'),
+                      ),
+                    ],
+                  ),
+                ),
+                Expanded(
+                  child: Row(
+                    children: <Widget>[
+                      Expanded(
+                        child: Padding(
+                          padding: const EdgeInsets.all(12),
+                          child: _TaskList(
+                            items: state.filteredItems,
+                            selected: state.selectedItemIds,
+                            onToggle: (String id) => bloc
+                                .add(OutboundCollectionSelectionToggled(id)),
+                          ),
+                        ),
+                      ),
+                      Expanded(
+                        child: Padding(
+                          padding: const EdgeInsets.all(12),
+                          child: _CollectionList(records: state.collectionRecords),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _TaskList extends StatelessWidget {
+  const _TaskList({
+    required this.items,
+    required this.selected,
+    required this.onToggle,
+  });
+
+  final List<OutboundTaskItem> items;
+  final Set<String> selected;
+  final ValueChanged<String> onToggle;
+
+  @override
+  Widget build(BuildContext context) {
+    if (items.isEmpty) {
+      return const Center(child: Text('无任务明细'));
+    }
+    return ListView.builder(
+      itemCount: items.length,
+      itemBuilder: (BuildContext context, int index) {
+        final item = items[index];
+        return TaskItemTile(
+          item: item,
+          selected: selected.contains(item.outTaskItemId),
+          onSelected: (_) => onToggle(item.outTaskItemId),
+        );
+      },
+    );
+  }
+}
+
+class _CollectionList extends StatelessWidget {
+  const _CollectionList({required this.records});
+
+  final List<OutboundCollectionRecord> records;
+
+  @override
+  Widget build(BuildContext context) {
+    if (records.isEmpty) {
+      return const Center(child: Text('暂无采集记录'));
+    }
+    return ListView.builder(
+      itemCount: records.length,
+      itemBuilder: (BuildContext context, int index) {
+        return CollectionRecordTile(record: records[index]);
+      },
+    );
+  }
+}
+
+class _InfoChip extends StatelessWidget {
+  const _InfoChip({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Chip(
+      label: Text('$label: $value'),
+    );
+  }
+}

--- a/lib/modules/outbound/collection_task/widgets/collection_record_tile.dart
+++ b/lib/modules/outbound/collection_task/widgets/collection_record_tile.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+import '../models/outbound_collection_record.dart';
+
+class CollectionRecordTile extends StatelessWidget {
+  const CollectionRecordTile({super.key, required this.record});
+
+  final OutboundCollectionRecord record;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      dense: true,
+      title: Text('${record.matCode} 批次:${record.batchNo} 序列:${record.sn}'),
+      subtitle: Text('数量:${record.collectQty} 库位:${record.storeSite} ERP:${record.erpStore}'),
+    );
+  }
+}

--- a/lib/modules/outbound/collection_task/widgets/task_item_tile.dart
+++ b/lib/modules/outbound/collection_task/widgets/task_item_tile.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+
+import '../models/outbound_task_item.dart';
+
+class TaskItemTile extends StatelessWidget {
+  const TaskItemTile({
+    super.key,
+    required this.item,
+    required this.selected,
+    required this.onSelected,
+  });
+
+  final OutboundTaskItem item;
+  final bool selected;
+  final ValueChanged<bool?> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 4),
+      child: CheckboxListTile(
+        value: selected,
+        onChanged: onSelected,
+        title: Text('${item.matCode} (${item.matName})'),
+        subtitle: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text('库位: ${item.storeSite}  库房: ${item.storeRoom}'),
+            Text('任务数量: ${item.hintQty}  已采: ${item.collectedQty}'),
+            if (item.batchNo.isNotEmpty) Text('批次: ${item.batchNo}'),
+            if (item.sn.isNotEmpty) Text('序列号: ${item.sn}'),
+            if (item.erpStore.isNotEmpty) Text('ERP子库: ${item.erpStore}'),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- refactor the outbound collection controller into a Bloc with explicit events mapped to the existing business workflow
- add dedicated event definitions and keep the immutable state to preserve validation, submission, and navigation logic
- update the outbound collection page to provide the Bloc and dispatch events for scanning, submission, selection, and navigation actions

## Testing
- not run (dart/flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68da43a1047483309c2884bea97265e3